### PR TITLE
matrix math: fix twoport for S to T and T to S

### DIFF
--- a/src/math/matrix.cpp
+++ b/src/math/matrix.cpp
@@ -1933,7 +1933,7 @@ matrix twoport (matrix m, char in, char out) {
       res.set (0, 0, m (0, 1) - m (0, 0) * m (1, 1) / d);
       res.set (0, 1, m (0, 0) / d);
       res.set (1, 0, -m (1, 1) / d);
-      res.set (0, 1, 1.0 / d);
+      res.set (1, 1, 1.0 / d);
       break;
     case 'A': // S to A
       res = stoa (m);
@@ -1959,7 +1959,7 @@ matrix twoport (matrix m, char in, char out) {
       res.set (0, 0, m (0, 1) / d);
       res.set (0, 1, m (0, 0) - m (0, 1) * m (1, 0) / d);
       res.set (1, 0, 1.0 / d);
-      res.set (0, 1, -m (1, 0) / d);
+      res.set (1, 1, -m (1, 0) / d);
       break;
     case 'T': // T to T
       res = m;


### PR DESCRIPTION
S_22 and T_22 are not set at all (looks like copy-paste error)

The correct formulas can be found at:
http://qucs.sourceforge.net/tech/node98.html

Signed-off-by: Thorsten Liebig <Thorsten.Liebig@gmx.de>