### PR TITLE
fix unsafe vector access, which leads to crash with _GLIBCXX_ASSERTIO…

### DIFF
--- a/src/nodelist.cpp
+++ b/src/nodelist.cpp
@@ -153,6 +153,7 @@ void nodelist::assignNodes (void) {
   // create fast array access possibility
   narray.clear();
   narray.reserve(this->length());
+  narray.resize(1);
 
   for (auto n: root) {
     // ground node gets a zero counter
@@ -162,6 +163,7 @@ void nodelist::assignNodes (void) {
     }
     // others get a unique number greater than zero
     else {
+      narray.resize(i+1);
       narray[i] = n;
       n->n = i++;
     }


### PR DESCRIPTION
This is a fix for issue #29 
I reproduced the crash by compiling qucs with
make CXXFLAGS='-D _GLIBCXX_ASSERTIONS -g'

I reproduced the crash with
qucsator -i ~/.qucs/netlist.txt 

then I did
coredumpctl gdb qucsator
and
the command bt inside gdb to examine the core dump. 

I used gdb together with the provided netlist
gdb --args ./qucsator -i <path_to_netlist>/netlist.txt
to examine the function nodelist::assignNodes
