### PR TITLE
Fix various typos

### DIFF
--- a/BUGS
+++ b/BUGS
@@ -38,7 +38,7 @@ Date:	     2005-03-01
 Description: Depending on the netlist input order it may occur that a DC
 	     analysis converges or does not converge (under-determined
 	     equation system?).
-Fix:	     The example netlists I had for this case are almostly
+Fix:	     The example netlists I had for this case are almost
 	     rank-deficient MNA matrices.  Thus another, numerically more
 	     stable, matrix decomposition algorithm has been implemented:
 	     the QR decomposition using Householder transformations.  The

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,8 +147,8 @@ endif()
 # ~~~
 # Need Bison
 #
-# This is a HACK to get arround a PATH issue with Qt Creator on OSX.
-# It seams impossible to pass a custom PATH to Qt Creator on OSX, ie, cannot prepend `/usr/local/bin/` for intance.
+# This is a HACK to get around a PATH issue with Qt Creator on OSX.
+# It seams impossible to pass a custom PATH to Qt Creator on OSX, ie, cannot prepend `/usr/local/bin/` for instance.
 # The FIND_PACKAGE fails. For now we provide a fallback with a custom FIND_PROGRAM.
 # The variable BISON_DIR is also available.
 # ~~~
@@ -193,7 +193,7 @@ endif()
 # Check if admsXml is available
 #
 # * Use -DADMSXML_DIR=[path] to give the path containing admsXml
-# * Try a few othe locations
+# * Try a few other locations
 #
 find_program(
   ADMSXML admsXml
@@ -241,7 +241,7 @@ endif()
 # Initialize CXXFLAGS.
 
 # \todo fix headers and use standard C++ methods * strdup is not C or C++
-# standart, it is POSIX adding -fpermissive let it compile with a ton of
+# standard, it is POSIX adding -fpermissive let it compile with a ton of
 # warnings * problem with non-starndart _stricmp using -stdr=c++0x set g++ into
 # strict ANSY, relax that with -U__STRICT_ANSI__. Could use -std=gnu++0x
 # ~~~
@@ -273,7 +273,7 @@ else()
 endif()
 
 #
-# Set position independed code PIC
+# Set position independent code PIC
 #
 if(UNIX AND NOT APPLE)
   if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")

--- a/RELEASE
+++ b/RELEASE
@@ -29,7 +29,7 @@ Distribution process:
   - Make sure INSTALL, THANKS and README files are up to date.
 
 * Test build and packaging.
-  - Maintainance currently requires the following software packages:
+  - Maintenance currently requires the following software packages:
      + Autoconf version 2.64 (at least)
      + GNU automake 1.7.0 (at least)
      + flex 2.5.31 (but at least 2.5.9)

--- a/THANKS
+++ b/THANKS
@@ -59,4 +59,4 @@ Mike Brinson <mbrin72043@yahoo.co.uk> for testing the EDD component
 	during his modelling activities.  Also for the Verilog-A
 	implementation of the modular operational amplifier.  Thanks for
 	testing the SPICE to qucs converter and documenting the
-	compatibilty levels.
+	compatibility levels.

--- a/cmake/complex_polar.cpp
+++ b/cmake/complex_polar.cpp
@@ -1,5 +1,5 @@
 /*
- * Check whehter you have the complex polar (double, double) function.
+ * Check whether you have the complex polar (double, double) function.
  */
 
 # include <complex>

--- a/configure.ac
+++ b/configure.ac
@@ -54,7 +54,7 @@ m4_define([CHECK_CLANG13530_PROGRAM],dnl
 			     #include <iostream>
 			   ],
 			   [std::cout << "Hello, world!" << std::endl;])])
-AC_MSG_CHECKING([wether c++ compiler is affected by clang bug 13530])
+AC_MSG_CHECKING([whether c++ compiler is affected by clang bug 13530])
 AC_LANG_PUSH(C++)
 AS_IF([test "x$ax_cv_cxx_compiler_vendor" = "xclang"],
       [dnl
@@ -71,7 +71,7 @@ AS_IF([test "x$ax_cv_cxx_compiler_vendor" = "xclang"],
 			[dnl
 			   clang13530_workarround_needed="yes"
 			],
-			[AC_MSG_FAILURE([Cannot compile test suite for clang 13530 even with workarround])])
+			[AC_MSG_FAILURE([Cannot compile test suite for clang 13530 even with workaround])])
 		  AX_RESTORE_FLAGS
 		]dnl
 	)dnl
@@ -186,9 +186,9 @@ AC_ARG_WITH(macosx-sdk,
 			  e. g.: --with-macosx-sdk=10.6
 
 			  there are 3 options to control the MacOSX build:
-			  --with-macosx-sdk (refered as 'sdk' below)
-			  --with-macosx-version-min-required (refered as 'min' below)
-			  --with-macosx-version-max-allowed (refered as 'max' below)
+			  --with-macosx-sdk (referred to as 'sdk' below)
+			  --with-macosx-version-min-required (referred to as 'min' below)
+			  --with-macosx-version-max-allowed (referred to as 'max' below)
 
 			  the connection between these value and the default they take is as follow:
 			  ( ? means not specified on the command line, s means the SDK version found,
@@ -209,7 +209,7 @@ AC_ARG_WITH(macosx-sdk,
 
 
 			  see: http://developer.apple.com/library/mac/#technotes/tn2064/_index.html
-			  for a detailled technical explanation of these variables
+			  for a detailed technical explanation of these variables
 
 			  Note: MACOSX_DEPLOYMENT_TARGET will be set to the value of 'min'.
 
@@ -529,14 +529,14 @@ case $host_os in
 
   AC_MSG_CHECKING([that macosx-version-min-required is coherent with macosx-version-max-allowed])
   if test $MAC_OS_X_VERSION_MIN_REQUIRED -gt $MAC_OS_X_VERSION_MAX_ALLOWED; then
-      AC_MSG_ERROR([the version minimumn required must be inferior or equal to the version maximum allowed])
+      AC_MSG_ERROR([the version minimum required must be inferior or equal to the version maximum allowed])
   else
       AC_MSG_RESULT([ok])
   fi
 
   AC_MSG_CHECKING([that macosx-version-max-allowed is coherent with macos-with-sdk])
   if test $MAC_OS_X_VERSION_MAX_ALLOWED -gt $MACOSX_SDK_VERSION; then
-      AC_MSG_ERROR([the version maximum allowed cannot be greater thatn the sdk level])
+      AC_MSG_ERROR([the version maximum allowed cannot be greater than the sdk level])
   else
       AC_MSG_RESULT([ok])
   fi
@@ -746,7 +746,7 @@ AC_CHECK_FUNCS([ \
 fabs \
 ])
 
-# Bessel funcions (libc ?)
+# Bessel functions (libc ?)
 AC_CHECK_FUNCS([ jn yn ])
 
 # C strings
@@ -805,7 +805,7 @@ dnl  polar \   skip, see below
 dnl C++11
   proj ])
 
-dnl funcions with gwo arguments
+dnl functions with two arguments
 AC_CHECK_CXX_COMPLEX_POW
 AC_CHECK_CXX_COMPLEX_ATAN2
 AC_CHECK_CXX_COMPLEX_FMOD
@@ -813,7 +813,7 @@ AC_CHECK_CXX_COMPLEX_POLAR
 AC_CHECK_CXX_COMPLEX_POLAR_COMPLEX
 
 
-dnl Depending on the implementation, funcions may or may not be included on the std namespace
+dnl Depending on the implementation, functions may or may not be included on the std namespace
 AC_MSG_NOTICE([Check for functions in std:: namespace])
  for f in std::acosh std::asinh std::atanh std::hypot std::trunc std::round std::erf std::erfc; do
     AC_MSG_CHECKING([for $f])

--- a/m4/ax_prefix_config_h.m4
+++ b/m4/ax_prefix_config_h.m4
@@ -29,7 +29,7 @@
 #
 #   Your configure.ac script should contain both macros in this order, and
 #   unlike the earlier variations of this prefix-macro it is okay to place
-#   the AX_PREFIX_CONFIG_H call before the AC_OUTPUT invokation.
+#   the AX_PREFIX_CONFIG_H call before the AC_OUTPUT invocation.
 #
 #   Example:
 #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,7 +108,7 @@ configure_file("${qucs-core_SOURCE_DIR}/qucs_typedefs.h.cmake"
                "${qucs-core_BINARY_DIR}/qucs_typedefs.h")
 
 #
-# Check for library functions * not all functons seem to be used after defined.
+# Check for library functions * not all functions seem to be used after defined.
 # TODO check for HAVE_{func}
 #
 include(CheckFunctionExists)

--- a/src/ChangeLog
+++ b/src/ChangeLog
@@ -271,7 +271,7 @@
 	* environment.cpp: Added 'passing' attribute to variables in the
 	environment.  Thus computed values in an environment don't get
 	passed from the environment variables, but any others will be
-	passed as ususal (e.g. subcircuit parameters).
+	passed as usual (e.g. subcircuit parameters).
 
 2007-10-02  Stefan Jahn  <stefan@lkcc.org>
 
@@ -315,7 +315,7 @@
 	* differentiate.cpp: Fixed some memory leaks.
 
 	* equation.cpp: Added new property to an equation node 'skip'
-	indicating that the node (e.g. equation assigment) is skipped from
+	indicating that the node (e.g. equation assignment) is skipped from
 	evaluation when the solver is run.
 
 	* environment.cpp: Added new function which just evaluates (no
@@ -418,7 +418,7 @@
 2007-05-02  Stefan Jahn  <stefan@lkcc.org>
 
 	* evaluate.cpp: Using absolute value of complex result in
-	ifthenelse contruct.  This yields the same results as if using
+	ifthenelse construct.  This yields the same results as if using
 	absolute arguments for e.g. sqrt() and ln() if these are negative.
 	Added '!=' and '==' implementations for boolean arguments.
 
@@ -591,7 +591,7 @@
 	process; now trying to resolve that dependencies in the
 	component properties of the netlist.
 	Fixed a segfault bug when trying to detect variable chain of
-	an assigment which is actually not cyclic itself but involves
+	an assignment which is actually not cyclic itself but involves
 	a variable which is cyclic.
 
 	* equation.h (class checker): Add a netlist entries to the
@@ -654,15 +654,15 @@
 	* equation.cpp: New function checking if a given variable name
 	is an equation.
 
-	* environment.cpp: Added children funtionality for environments.
+	* environment.cpp: Added children functionality for environments.
 
 	* check_netlist.cpp: Resolving variables in equations.
-	Creating a real environment tree.  Checking equtions in all
+	Creating a real environment tree.  Checking equations in all
 	subcircuits as well.
 
 2006-10-09  Stefan Jahn  <stefan@lkcc.org>
 
-	* trsolver.cpp: Fixed a bug in the transient solver occuring
+	* trsolver.cpp: Fixed a bug in the transient solver occurring
 	when a components MNA matrix changes during DC and TR (e.g.
 	transmission line).
 
@@ -764,7 +764,7 @@
 
 2006-08-08  Stefan Jahn  <stefan@lkcc.org>
 
-	* parasweep.cpp: Fixed a bug occuring with multi-dimensional
+	* parasweep.cpp: Fixed a bug occurring with multi-dimensional
 	s-parameter sweeps which require a prior dc analysis.  Now the
 	data dependency tracking works again.
 
@@ -957,7 +957,7 @@
 	getRow(), set(val) as well as '+=' and '-=' operators.
 
 	* hbsolver.cpp: Implemented non-linear part of the harmonic
-	balance as far as possible.  All parts of the algorithm adressed
+	balance as far as possible.  All parts of the algorithm addressed
 	but not yet working...
 
 2006-04-06  Stefan Jahn  <stefan@lkcc.org>
@@ -1117,7 +1117,7 @@
 	specifications.
 
 	* scan_netlist.l: Had to revert acceptance of signed real
-	values.  Grammer wouldn't even work for "1+1"... Now implemented
+	values.  Grammar wouldn't even work for "1+1"... Now implemented
 	ranges in the right way.
 
 2006-02-05  Stefan Jahn  <stefan@lkcc.org>

--- a/src/analysis.h
+++ b/src/analysis.h
@@ -113,7 +113,7 @@ public:
     virtual ~analysis ();
 
     /*! \fn solve
-    * \brief placehoder for solution function
+    * \brief placeholder for solution function
     *
     * Virtual solution function intended to be overridden by the
     * inheiriting class's solution function.
@@ -124,7 +124,7 @@ public:
     }
 
     /*! \fn initialize
-    * \brief placehoder for initialization function
+    * \brief placeholder for initialization function
     *
     * Virtual initialize function intended to be overridden by the
     * inheiriting class's initialization function.
@@ -135,7 +135,7 @@ public:
     }
 
     /*! \fn cleanup
-    * \brief placehoder for cleanup function
+    * \brief placeholder for cleanup function
     *
     * Virtual cleanup function intended to be overridden by the
     * inheiriting class's cleanup function.

--- a/src/circuit.cpp
+++ b/src/circuit.cpp
@@ -755,7 +755,7 @@ void circuit::voltageSource (int n, int pos, int neg, nr_double_t value) {
 
 /* The function runs the necessary calculation in order to perform a
    single integration step of a voltage controlled capacitance placed
-   in between the given nodes.  It is assumed that the appropiate
+   in between the given nodes.  It is assumed that the appropriate
    charge only depends on the voltage between these nodes. */
 void circuit::transientCapacitance (int qstate, int pos, int neg,
 				    nr_double_t cap, nr_double_t voltage,
@@ -813,7 +813,7 @@ void circuit::transientCapacitanceQ (int qstate, int qpos,
 
 /* This function stores the Jacobian entries due to the C = dQ/dV
    value.  The nodes where the charge is located as well as those of
-   the voltage dependency, the appropiate capacitance value and the
+   the voltage dependency, the appropriate capacitance value and the
    voltage across the the controlling branch must be given.  It also
    saves the current contributions which are necessary for the NR
    iteration and considers the polarity of the circuit. */

--- a/src/circuit.h
+++ b/src/circuit.h
@@ -113,7 +113,7 @@ class circuit : public object, public integrator
   // functionality to be overloaded by real, derived circuit element
   // implementations
   /*! \fn initSP
-   * \brief placehoder for S-Parameter initialisation function
+   * \brief placeholder for S-Parameter initialisation function
    *
    * Virtual function intended to be overridden by the
    * inheiriting circuit element's S-Parameter initialisation
@@ -172,7 +172,7 @@ class circuit : public object, public integrator
    */
   bool   isEnabled (void) { return RETFLAG (CIRCUIT_ENABLED); }
   /*! \fn setEnabled
-   * \brief Set a circuit element to be enabled or diabled.
+   * \brief Set a circuit element to be enabled or disabled.
    * \param e boolean indicating whether to enable or disable
    *
    * Sets the circuit element to be enabled or disabled.

--- a/src/components/ChangeLog
+++ b/src/components/ChangeLog
@@ -236,7 +236,7 @@
 
 2007-05-01  Stefan Jahn  <stefan@lkcc.org>
 
-	* devices/eqndefined.cpp: Fixed bug occuring when there are
+	* devices/eqndefined.cpp: Fixed bug occurring when there are
 	multiple instances of an EDD enclosed in a sub-circuit.  These
 	reuse the equations in the environment.
 

--- a/src/components/capacitor.cpp
+++ b/src/components/capacitor.cpp
@@ -25,7 +25,7 @@
 /*!\file capacitor.cpp
    \brief capacitor class implementation
 
-   A capacitor is a passive device that strore electric energy
+   A capacitor is a passive device that stores electrical energy
 */
 
 

--- a/src/components/circline.cpp
+++ b/src/components/circline.cpp
@@ -30,7 +30,7 @@
 /*
 References:
 Microwave Engineering. David M Pozar. John Wiley and Sons. 4th Edition. Pg 121-130
-Fundation for Microwave Engineering. IEEE Press. Robert E. Collin. 2d edition. Pg 194-198
+Foundation for Microwave Engineering. IEEE Press. Robert E. Collin. 2d edition. Pg 194-198
        1992
 */
 

--- a/src/components/devices/mosfet.cpp
+++ b/src/components/devices/mosfet.cpp
@@ -249,7 +249,7 @@ void mosfet::initModel (void) {
       if (Nsub * 1e6 >= NiSi) {
 	Phi = 2 * Ut * qucs::log (Nsub * 1e6 / NiSi);
       } else {
-	logprint (LOG_STATUS, "WARNING: substrate doping less than instrinsic "
+	logprint (LOG_STATUS, "WARNING: substrate doping less than intrinsic "
 		  "density, adjust Nsub >= %g\n", NiSi / 1e6);
 	Phi = 0.6;
       }

--- a/src/components/microstrip/cpwline.cpp
+++ b/src/components/microstrip/cpwline.cpp
@@ -200,7 +200,7 @@ void cpwline::initPropagation (void) {
   nr_double_t v = 0.43 - (0.86 - 0.54 * p) * p;
   G = qucs::exp (u * qucs::log (W / s) + v);
 
-  // loss constant factors (computed only once for efficency sake)
+  // loss constant factors (computed only once for efficiency sake)
   nr_double_t ac = 0;
   if (t > 0) {
     // equations by GHIONE

--- a/src/components/rectline.cpp
+++ b/src/components/rectline.cpp
@@ -41,7 +41,7 @@
        1998
        isbn 0-471-17096-8
 
-   [2] Fundation for Microwave Engineering
+   [2] Foundation for Microwave Engineering
        The {IEEE} press serie on Electromagnetics Wave Theory
        Robert E. Collin
        IEEE Press,

--- a/src/components/taperedline.cpp
+++ b/src/components/taperedline.cpp
@@ -56,7 +56,7 @@ void taperedline::calcABCDparams(nr_double_t frequency)
   nr_double_t beta = 2*pi*frequency/C0; //Propagation constant
   nr_complex_t gamma = nr_complex_t (alpha, beta); //Complex propagation constant
   matrix ABCD_ = eye(2);//Overall ABCD matrix
-  matrix ABCDaux = eye(2);//Auxiliar matrix for performing the iterative product
+  matrix ABCDaux = eye(2);//Auxiliary matrix for performing the iterative product
   nr_double_t Zi;
   nr_complex_t a, b, c, d;
   // ABCD coefficients
@@ -172,7 +172,7 @@ nr_double_t L = getPropertyDouble ("L");//Length
 }
 
 //------------------------------------------------------------------
-// Auxiliar function for Klopfenstein profile calculation
+// Auxiliary function for Klopfenstein profile calculation
 // The recursive calculation algorithm is from
 //   Grossberg, M. A., "Extremely rapid computation of the Klopfenstein
 //   impedance taper," IEEE Proc., vol.56, no.9, pp.1629-1630, Sept. 1968

--- a/src/components/verilog/CMakeLists.txt
+++ b/src/components/verilog/CMakeLists.txt
@@ -45,7 +45,7 @@ set(VA_FILES
     tff_SR.va
     vcresistor.va)
 
-# XML sripts need to build, the order matters
+# XML scripts need to build, the order matters
 set(XML_BUILD
    analogfunction.xml
    qucsVersion.xml

--- a/src/components/verilog/ChangeLog
+++ b/src/components/verilog/ChangeLog
@@ -200,7 +200,7 @@
 
 2007-12-11  Stefan Jahn  <stefan@lkcc.org>
 
-	* qucsVersion.xml: Implemented $strobe() and $finish() corretly
+	* qucsVersion.xml: Implemented $strobe() and $finish() correctly
 	now.  Simple (only for numeric case items) but working 'case'
 	implementation added.
 

--- a/src/components/verilog/EKV26MOS.va
+++ b/src/components/verilog/EKV26MOS.va
@@ -86,7 +86,7 @@ electrical Drain_int, Source_int;
  parameter real Kf = 1.0e-27 from [0.0 :inf]   `attr(info="flicker noise coefficient");
  parameter real Af = 1.0 from [0.0 : inf]      `attr(info="flicker noise exponent" );
 // Matching parameters
- parameter real Avto = 0.0 from [0.0 :inf]     `attr(info="area related theshold voltage mismatch parameter" unit = "V*m");
+ parameter real Avto = 0.0 from [0.0 :inf]     `attr(info="area related threshold voltage mismatch parameter" unit = "V*m");
  parameter real Akp = 0.0 from [0.0 : inf]     `attr(info="area related gain mismatch parameter" unit="m");
  parameter real Agamma = 0.0 from [0.0 : inf]  `attr(info="area related body effect mismatch parameter" unit="sqrt(V)*m");
 // Diode parameters

--- a/src/components/verilog/MESFET.va
+++ b/src/components/verilog/MESFET.va
@@ -118,7 +118,7 @@ electrical n1, n2, n3, n4;
  parameter real Rstc = 0 from [-inf : inf]
   `attr(info="source resistance temperature coefficient" unit = "1/Celsius");
  parameter real Ibv = 1e-3 from [1e-25 : inf]
-  `attr(info="gate reverse breakdown currrent" unit = "A");
+  `attr(info="gate reverse breakdown current" unit = "A");
  parameter real Rf = 10 from [1e-9 : inf]
   `attr(info="forward bias slope resistance" unit = "Ohms");
  parameter real R1 = 10 from [1e-9 : inf]

--- a/src/components/verilog/Makefile.am
+++ b/src/components/verilog/Makefile.am
@@ -113,7 +113,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/src -I$(top_srcdir)/src/math \
 
 ## configure determines if we want to build and use the
 ## bundled version of ADMS, or the host's ADMS. Here we
-## set the path to the admsXml binary depeding on the choice
+## set the path to the admsXml binary depending on the choice
 ## the user made at configure time
 
 GENERATED_FILES = *.core.* *.analogfunction.* *.gui.* *.defs.* .*.adms .*.xml

--- a/src/components/verilog/mod_amp.va
+++ b/src/components/verilog/mod_amp.va
@@ -45,7 +45,7 @@
  parameter real NSRT = 5e5 from [1 : inf]
   `attr(info="Negative slew rate (V/s)");
  parameter real VLIMP = 14 from [0.01 : inf]
-  `attr(info="Positve output voltage limit (V)");
+  `attr(info="Positive output voltage limit (V)");
  parameter real VLIMN = -14 from [-inf : 0]
   `attr(info="Negative output voltage limit (V)");
  parameter real ILMAX = 35e-3 from [1e-9 : inf]

--- a/src/components/verilog/qucsMODULEcore.xml
+++ b/src/components/verilog/qucsMODULEcore.xml
@@ -30,7 +30,7 @@
 <admst:variable name="nbr_sources_flickernoise" select="%s"/>
 </admst:for-each>
 
-<!-- parse ADMS command line arguments, needs to be outside admst:open, keep last comand -->
+<!-- parse ADMS command line arguments, needs to be outside admst:open, keep last command -->
 <!-- output filename is 1st argument in -o flag in command line-->
 <admst:variable name="filename" select="%(/module/name)_common"/>
 <admst:variable name="filename_state" select="0"/>
@@ -736,7 +736,7 @@ using qucs::matrix;
 #include &quot;$(filename).defs.h&quot;
 
 
-<!-- emmit code for the dynamic loader -->
+<!-- emit code for the dynamic loader -->
 <admst:text format="\n// loader constructor interface\n"/>
 <admst:text format="#ifdef QUCSADMS_DYLOAD\n"/>
 <admst:text format="extern &quot;C&quot; {\n"/>

--- a/src/components/verilog/qucsMODULEdefs.xml
+++ b/src/components/verilog/qucsMODULEdefs.xml
@@ -128,7 +128,7 @@
   <admst:text format="&quot;%(value)&quot;"/>
 </admst:template>
 
-<!-- recurse, till it retuns the value of the independent variable -->
+<!-- recurse, till it returns the value of the independent variable -->
 <admst:template match=":variable">
   <!-- admst:text format="&quot;%(name)&quot;"/ -->
   <admst:apply-templates select="default" match=":expression"/>

--- a/src/components/verilog/qucsVersion.xml
+++ b/src/components/verilog/qucsVersion.xml
@@ -951,7 +951,7 @@
       <admst:assert test="arguments[2]/adms[datatypename='probe']" format="%(name): second argument is not a probe\n"/>
       <admst:apply-templates select="arguments[1]" match="ddx"/>
       <!--
-      FIXME what does  not-used is suposed do mean??,
+      FIXME what does 'not-used' supposed to mean??,
        partial derivative of a independent variable? if so, return zero...
 
       <admst:variable name="e" select="not-used"/>

--- a/src/components/verilog/va2cpp.makefile
+++ b/src/components/verilog/va2cpp.makefile
@@ -16,7 +16,7 @@ PREFIX=
 # Location of installed Qucs XML files
 INC=$(PREFIX)/include/qucsator
 
-# Locate admsXml, typicaly on the same prefix as Qucs
+# Locate admsXml, typically on the same prefix as Qucs
 ADMSXML=$(PREFIX)/bin/admsXml
 
 # file suffix

--- a/src/consts.h
+++ b/src/consts.h
@@ -82,7 +82,7 @@ static const double sqrt2 = 1.4142135623730950488016887242096981;
 /*!\brief Inverse of Square root of 2 (\f$1/\sqrt{2}\f$) */
 static const double sqrt1_2 = 0.7071067811865475244008443621048490;
 
-/*!\brief Limiting exponetial factor */
+/*!\brief Limiting exponential factor */
 static const double limitexp = 80.0;
 
 /**

--- a/src/converter/ChangeLog
+++ b/src/converter/ChangeLog
@@ -40,8 +40,8 @@
 	refer to voltage sources) in the node list of F and H controlled
 	sources.
 
-	* scan_spice.l: Explicitely scanning suffixes and unit for (real)
-	values in oder to allow e.g. '11x' node names.
+	* scan_spice.l: Explicitly scanning suffixes and unit for (real)
+	values in order to allow e.g. '11x' node names.
 
 	* qucs_producer.cpp: Fixed bug while referencing subcircuits
 	(missing 'X' when it starts with a digit).
@@ -347,7 +347,7 @@
 2006-03-09  Stefan Jahn  <stefan@lkcc.org>
 
 	* csv_producer.cpp (csv_producer): When exporting a dependent
-	variable export it in the last column, the dependecies in the
+	variable export it in the last column, the dependencies in the
 	first columns.
 
 2006-03-05  Stefan Jahn  <stefan@lkcc.org>
@@ -447,7 +447,7 @@
 
 	* qucs_producer.cpp: Fixed reference node implementation in
 	order to pull the ground node outside the circuit definition
-	througout the subcircuits in the original netlist.
+	throughout the subcircuits in the original netlist.
 
 2005-04-27  Stefan Jahn  <stefan@lkcc.org>
 
@@ -484,7 +484,7 @@
 	used to inhibit the output of simulations (actions) into
 	the resulting netlist.
 
-	* parse_spice.y: Almostly implemented all of the Spice
+	* parse_spice.y: Almost implemented all of the Spice
 	'grammar' in the netlist parser.
 
 	* check_spice.cpp: Implemented evaluation of the .OPTIONS

--- a/src/converter/check_spice.cpp
+++ b/src/converter/check_spice.cpp
@@ -2080,7 +2080,7 @@ spice_translate_coupled_x (struct definition_t * root,
   return root;
 }
 
-/* Contructs an edd equation name. */
+/* Constructs an edd equation name. */
 static char *
 spice_create_eqnstr (struct definition_t * def, int p, char type) {
   char * n = (char *) malloc (strlen (def->instance) + 4 + 3);
@@ -2192,7 +2192,7 @@ static char *
 spice_create_poly (struct value_t * prop, int nd, int integrate) {
   struct value_t * val;
 
-  // contruct polynomial expression
+  // construct polynomial expression
   int * pn = (int *) calloc (nd, sizeof (int));
   static char expr[1024];
   char value[256];
@@ -2278,7 +2278,7 @@ spice_translate_poly (struct definition_t * root, struct definition_t * def) {
     nd = (int) spice_evaluate_value (prop);
     spice_value_done (prop);
 
-    // contruct properties, equations and nodes of the EDD
+    // construct properties, equations and nodes of the EDD
     if (type <= 1) {
       // handle E and G voltage controlled sources
       prop = prop->next;
@@ -2341,7 +2341,7 @@ spice_translate_poly (struct definition_t * root, struct definition_t * def) {
     struct definition_t * ieqn, * qeqn;
     root = spice_add_edd_equation (root, def, 1, &ieqn, &qeqn);
 
-    // contruct polynomial expression
+    // construct polynomial expression
     char * expr = spice_create_poly (prop, nd, 0);
 
     // replace first current branch to reflect polynom
@@ -2415,7 +2415,7 @@ spice_translate_poly_lc (struct definition_t * root,
     struct definition_t * ieqn, * qeqn;
     root = spice_add_edd_equation (root, def, 1, &ieqn, &qeqn);
 
-    // contruct polynomial expression
+    // construct polynomial expression
     char * expr1 = strdup (spice_create_poly (prop, 1, 1));
     char * expr2 = expr1;
     if (lc != 0.0) {

--- a/src/converter/check_vcd.h
+++ b/src/converter/check_vcd.h
@@ -144,7 +144,7 @@ struct vcd_file {
 // A VCD variable.
 struct vcd_variable {
   char * code;  // identifier code, references 'var'
-  char * ident; // variable identifer
+  char * ident; // variable identifier
   char * value; // the value
   int isreal;   // indicates type of value
   int type;     // variable type

--- a/src/converter/parse_spice.ypp
+++ b/src/converter/parse_spice.ypp
@@ -478,7 +478,7 @@ DefinitionLine:
     $$->values = $2;
   }
   | TEMP_Action ValueList Eol {
-    /* temperatur analysis (Spice 2g6) */
+    /* temperature analysis (Spice 2g6) */
     $$ = spice_create_action ($1, strdup ($1));
     $$->values = $2;
   }

--- a/src/environment.cpp
+++ b/src/environment.cpp
@@ -300,7 +300,7 @@ void environment::setValue (char * n, constant * value) {
 // Short helper macro.
 #define A(a) ((assignment *) (a))
 
-/* The function puts local variables (prameters and equation results)
+/* The function puts local variables (parameters and equation results)
    into the set of environment variables. */
 void environment::saveResults (void) {
   node * equations = checkee->getEquations ();

--- a/src/eqnsys.cpp
+++ b/src/eqnsys.cpp
@@ -1367,7 +1367,7 @@ void eqnsys<nr_type_t>::givens_apply_v (int r1, int r2,
   }
 }
 
-/*! This function diagonalizes the upper bidiagonal matrix fromed by
+/*! This function diagonalizes the upper bidiagonal matrix formed by
    the diagonal S and the super-diagonal vector E.  Both vectors are
    real valued.  Thus real valued calculations even when solving a
    complex valued equation systems is possible except for the matrix

--- a/src/equation.cpp
+++ b/src/equation.cpp
@@ -1108,7 +1108,7 @@ void node::append (node * last)
     n->setNext (last);
 }
 
-// Appends othere nodes to the equation node object.
+// Appends other nodes to the equation node object.
 void node::appendNodes (node * last)
 {
     if (!last) return;

--- a/src/evaluate.cpp
+++ b/src/evaluate.cpp
@@ -4692,7 +4692,7 @@ constant * evaluate::assert_b(constant *args)
 {
     _ARB0(b0);
     if(!b0) {
-	THROW_MATH_EXCEPTION ("assert failled");
+	THROW_MATH_EXCEPTION ("assert failed");
 	abort();
      }
      _DEFB ();
@@ -4704,7 +4704,7 @@ constant * evaluate::assert_d(constant *args)
 {
     _ARD0(d0);
     if(d0 == 0.0) {
-        THROW_MATH_EXCEPTION ("assert failled");
+        THROW_MATH_EXCEPTION ("assert failed");
 	abort();
     }
      _DEFB ();
@@ -4716,7 +4716,7 @@ constant * evaluate::assert_v (constant * args) {
   _ARV0 (v0);
   for (int i = 0; i < v0->getSize (); i++) {
     if( v0->get(i) == 0.0 ) {
-	THROW_MATH_EXCEPTION ("assert failled");
+	THROW_MATH_EXCEPTION ("assert failed");
 	abort();
     }
   }
@@ -4729,7 +4729,7 @@ constant * evaluate::bugon_b(constant *args)
 {
     _ARB0(b0);
     if(b0) {
-	THROW_MATH_EXCEPTION ("bugon failled");
+	THROW_MATH_EXCEPTION ("bugon failed");
 	abort();
      }
      _DEFB ();
@@ -4741,7 +4741,7 @@ constant * evaluate::bugon_d(constant *args)
 {
     _ARD0(d0);
     if(d0 != 0.0) {
-	THROW_MATH_EXCEPTION ("bugon failled");
+	THROW_MATH_EXCEPTION ("bugon failed");
 	abort();
      }
      _DEFB ();
@@ -4753,7 +4753,7 @@ constant * evaluate::bugon_v (constant * args) {
   _ARV0 (v0);
   for (int i = 0; i < v0->getSize (); i++) {
     if( v0->get(i) != 0.0 ) {
-	THROW_MATH_EXCEPTION ("bugon failled");
+	THROW_MATH_EXCEPTION ("bugon failed");
 	abort();
     }
   }

--- a/src/hbsolver.cpp
+++ b/src/hbsolver.cpp
@@ -365,14 +365,14 @@ void hbsolver::expandFrequencies (nr_double_t f, int n) {
 
 // Calculates an order fulfilling the "power of two" requirement.
 int hbsolver::calcOrder (int n) {
-  int o, order = n * 2;             // current order + DC + negative freqencies
+  int o, order = n * 2;             // current order + DC + negative frequencies
   for (o = 1; o < order; o <<= 1) ; // a power of 2
   return o / 2 - 1;
 }
 
 /* The function computes the harmonic frequencies excited in the
    circuit list depending on the maximum number of harmonics per
-   exitation and saves its results into the 'negfreqs' vector. */
+   excitation and saves its results into the 'negfreqs' vector. */
 void hbsolver::collectFrequencies (void) {
 
   // initialization
@@ -385,7 +385,7 @@ void hbsolver::collectFrequencies (void) {
   // obtain order
   int i, n = calcOrder (getPropertyInteger ("n"));
 
-  // expand frequencies for each exitation
+  // expand frequencies for each excitation
   nr_double_t f;
   for (auto * c : excitations) {
     if (c->getType () != CIR_VDC) { // no extra DC sources
@@ -773,7 +773,7 @@ void hbsolver::createMatrixLinearY (void) {
     estack.print ();
   }
 
-  // aquire variable transimpedance matrix entries
+  // acquire variable transimpedance matrix entries
   eqns.setAlgo (ALGO_LU_SUBSTITUTION_CROUT);
   for (c = 0; c < sn; c++) {
     I->set (0.0);
@@ -799,7 +799,7 @@ void hbsolver::createMatrixLinearY (void) {
   // create constant transimpedance matrix entries relating the
   // source voltages to the interconnection currents
   int vsrc = 0;
-  // aquire constant transadmittance matrix entries
+  // acquire constant transadmittance matrix entries
   for (auto it = excitations.begin(); it != excitations.end(); ++it, vsrc++) {
     circuit * vs = *it;
     // get positive and negative node
@@ -1091,7 +1091,7 @@ void hbsolver::loadMatrices (void) {
 
 /* The following function transforms a vector using a Fast Fourier
    Transformation from the time domain to the frequency domain. 
-   \todo rewrite ugly sould die
+   \todo rewrite ugly should die
 */
 void hbsolver::VectorFFT (tvector<nr_complex_t> * V, int isign) {
   int i, k, r;

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -104,7 +104,7 @@ nr_double_t history::interpol (nr_double_t tval, int idx, bool left) {
 }
 
 /* The function returns the value nearest to the given time value.  If
-   the otional parameter is true then additionally cubic spline
+   the optional parameter is true then additionally cubic spline
    interpolation is used. */
 nr_double_t history::nearest (nr_double_t tval, bool interpolate) {
   if (t->empty())

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -155,7 +155,7 @@ void input::factory (void) {
 	      }
 	    }
 	    else {
-	      // ususal string property
+	      // usual string property
 	      a->addProperty (pairs->key, pairs->value->ident);
 	    }
 	  } else {

--- a/src/interface/asynctrcircuit.m
+++ b/src/interface/asynctrcircuit.m
@@ -1,5 +1,5 @@
 classdef asynctrcircuit < qucstrans
-    % asynchonous circuit solver for use with the ode integrator routines
+    % asynchronous circuit solver for use with the ode integrator routines
     % based on an interface to the qucs transient circuit solvers
     %
     %

--- a/src/interface/cppinterface.m
+++ b/src/interface/cppinterface.m
@@ -46,7 +46,7 @@ classdef cppinterface < handle
         %% C++ Function Call
         function varargout = cppcall(this, varargin)
             
-            % call the mex funtion with the supplied keyword and the object
+            % call the mex function with the supplied keyword and the object
             % handle
             if numel(varargin) > 1
                 [varargout{1:nargout}] = this.mex_interface_fcn(varargin{1}, this.objectHandle, varargin{2:end});

--- a/src/interface/e_trsolver.h
+++ b/src/interface/e_trsolver.h
@@ -85,7 +85,7 @@ public:
       * \a V.
       *
       * You can set the voltage of ecvs components in subcircuits created
-      * by using a name up of the subcircuit heirarchy it is in, e.g. the
+      * by using a name up of the subcircuit hierarchy it is in, e.g. the
       * name
       *
       * SUBtop.SUBlower.ECVS1

--- a/src/interface/qucs_interface.cpp
+++ b/src/interface/qucs_interface.cpp
@@ -95,7 +95,7 @@ qucsint::~qucsint ()
     netlist_destroy_env ();
 }
 
-/*!\ todo: replace "root" by / as environement root */
+/*!\ todo: replace "root" by / as environment root */
 int qucsint::prepare_netlist (char * infile)
 {
 

--- a/src/interface/qucs_interface.h
+++ b/src/interface/qucs_interface.h
@@ -138,7 +138,7 @@ public:
       * \a V.
       *
       * You can set the voltage of ecvs components in subcircuits created
-      * by using a name up of the subcircuit heirarchy it is in, e.g. the
+      * by using a name up of the subcircuit hierarchy it is in, e.g. the
       * name
       *
       * SUBtop.SUBlower.ECVS1

--- a/src/math/cbesselj.cpp
+++ b/src/math/cbesselj.cpp
@@ -209,7 +209,7 @@ cbesselj_mediumarg (unsigned int n, nr_complex_t z)
 
 
 
-/*! \brief num of P(k) (n = 8) will overlow above this value */
+/*! \brief num of P(k) (n = 8) will overflow above this value */
 #define MAX_LARGE_ITERATION 430
 
 /*!\brief besselj for large argument

--- a/src/math/complex.cpp
+++ b/src/math/complex.cpp
@@ -274,11 +274,11 @@ nr_complex_t sqrt (const nr_complex_t z)
 }
 
 
-/*!\brief Compute euclidian norm of complex number
+/*!\brief Compute euclidean norm of complex number
 
    Compute \f$(\Re\mathrm{e}\;z )^2+ (\Im\mathrm{m}\;z)^2=|z|^2\f$
    \param[in] z Complex number
-   \return Euclidian norm of z
+   \return Euclidean norm of z
 */
 nr_double_t norm (const nr_complex_t z)
 {
@@ -349,7 +349,7 @@ nr_complex_t sech (const nr_complex_t z)
 
    \param[in] z complex arc
    \return argument hyperbolic secant of z
-   \todo for symetry reason implement sech
+   \todo for symmetry reason implement sech
 */
 nr_complex_t asech (const nr_complex_t z)
 {

--- a/src/math/matrix.cpp
+++ b/src/math/matrix.cpp
@@ -40,7 +40,7 @@
       Vol.82, Iss.5, May 1982
       Pages: 661- 666
 
-  [3] Comments on "A Rigorous Techique for Measuring the Scattering
+  [3] Comments on "A Rigorous Technique for Measuring the Scattering
       Matrix of a Multiport Device with a Two-Port Network Analyzer"
       Dropkin, H.
       Microwave Theory and Techniques, IEEE Transactions on,
@@ -113,7 +113,7 @@ matrix::matrix () {
 
     Constructor creates an unnamed instance of the matrix class with a
     certain number of rows and columns.  Particularly creates a square matrix.
-    \param[in] s number of rows or colums of square matrix
+    \param[in] s number of rows or columns of square matrix
     \todo Why not s const?
 */
 matrix::matrix (int s)  {
@@ -651,7 +651,7 @@ matrix pow (matrix a, int n) {
    The cofactor is preceded by a + or - sign depending of the sign
    of \f$(-1)^(u+v)\f$
 
-   \bug This algortihm is recursive! Stack overfull!
+   \bug This algorithm is recursive! Stack overfull!
    \todo ((u + v) & 1) is cryptic use (u + v)% 2
    \todo #ifdef 0
    \todo static?
@@ -680,7 +680,7 @@ nr_complex_t cofactor (matrix a, int u, int v) {
 
    See Wikipedia http://en.wikipedia.org/wiki/Laplace_expansion
    \param[in] a matrix
-   \bug This algortihm is recursive! Stack overfull!
+   \bug This algorithm is recursive! Stack overfull!
    \note assert square matrix
    \todo #ifdef 0
    \todo static ?
@@ -794,7 +794,7 @@ matrix inverseLaplace (matrix a) {
    elimination.
    \todo a const?
    \todo static?
-   \note assert non singulat matix
+   \note assert non singulat matrix
    \param[in] a matrix to invert
 */
 matrix inverseGaussJordan (matrix a) {
@@ -1402,7 +1402,7 @@ matrix ytoz (matrix y) {
    \param[in] cy Admittance noise correlation
    \param[in] s S parameter matrix of device
    \return S-parameter noise correlation matrix
-   \note Assert compatiblity of matrix
+   \note Assert compatibility of matrix
    \todo cy s const
 */
 matrix cytocs (matrix cy, matrix s) {
@@ -1455,7 +1455,7 @@ matrix cstocy (matrix cs, matrix y) {
    \param[in] cz Impedance noise correlation
    \param[in] s S parameter matrix of device
    \return S-parameter noise correlation matrix
-   \note Assert compatiblity of matrix
+   \note Assert compatibility of matrix
    \todo cz, s const
 */
 matrix cztocs (matrix cz, matrix s) {
@@ -1711,7 +1711,7 @@ void matrix::setBottomRightCorner(matrix m, int p, int q) {
   This function converts 2x2 matrices from any of the matrix forms Y,
   Z, H, G and A to any other.  Also converts S<->(A, T, H, Y and Z)
   matrices.
-  Convertion assumed:
+  Conversion assumed:
 
   Y->Y, Y->Z, Y->H, Y->G, Y->A, Y->S,
   Z->Y, Z->Z, Z->H, Z->G, Z->A, Z->S,
@@ -1970,7 +1970,7 @@ matrix twoport (matrix m, char in, char out) {
   return res;
 }
 
-/*!\brief Compute the Rollet stabilty factor
+/*!\brief Compute the Rollet stability factor
 
    The function returns the Rollet stability factor (\f$K\f) of the given
    S-parameter matrix:

--- a/src/math/real.cpp
+++ b/src/math/real.cpp
@@ -480,11 +480,11 @@ nr_double_t imag (const nr_double_t r) {
   return 0.0;
 }
 
-/*!\brief Compute euclidian norm of real number
+/*!\brief Compute euclidean norm of real number
 
    Compute \f$r^2\f$
    \param[in] r Real number
-   \return Euclidian norm of r
+   \return Euclidean norm of r
 */
 nr_double_t norm (const nr_double_t r) {
   return r * r;

--- a/src/math/real.h
+++ b/src/math/real.h
@@ -30,10 +30,10 @@
 
 #include <constants.h>
 
-/**It is prefered to add all used funcions into the qucs namespace.
+/**It is preferred to add all used functions into the qucs namespace.
  * Doing so one is forced do think about compatibility instead of using std directly.
  * Inline is optional at this moment
- * \todo test if inline indeed performace improves (optimization flags should inline them anyway)
+ * \todo test if inline indeed performance improves (optimization flags should inline them anyway)
  */
 
 namespace qucs {

--- a/src/module.cpp
+++ b/src/module.cpp
@@ -447,7 +447,7 @@ void module::registerDynamicModules (char *proj, std::list<std::string> modlist)
  *   - Add other methods to find the libraries
  *
  * Update
- *  * project path is passed as paramter
+ *  * project path is passed as parameter
  *  * module names are passed as parameter
 */
 

--- a/src/nasolver.cpp
+++ b/src/nasolver.cpp
@@ -1458,7 +1458,7 @@ std::string nasolver<nr_type_t>::createI (int n, const std::string &amps, int sa
 }
 
 
-/* Alternaive to countNodes () */
+/* Alternative to countNodes () */
 template <class nr_type_t>
 int nasolver<nr_type_t>::getN()
 {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -517,7 +517,7 @@ int net::checkCircuitChain (void) {
 }
 
 /* This function counts the number of signals (ports) within the list
-   of registerd circuits. */
+   of registered circuits. */
 int net::countPorts (void) {
   int count = 0;
   for (circuit * c = root; c != NULL; c = (circuit *) c->getNext ()) {

--- a/src/receiver.cpp
+++ b/src/receiver.cpp
@@ -180,7 +180,7 @@ vector * emi::receiver (nr_double_t * ida, nr_double_t duration, int ilength) {
 }
 
 /* This is a wrapper for the basic EMI rceiver functionality.  It
-   takes an arbitraty waveform in the time domain and interpolates it
+   takes an arbitrary waveform in the time domain and interpolates it
    such, that its length results in a power of two elements. */
 vector * emi::receiver (vector * da, vector * dt, int len) {
 

--- a/src/spsolver.cpp
+++ b/src/spsolver.cpp
@@ -113,7 +113,7 @@ circuit * spsolver::interconnectJoin (node * n1, node * n2) {
   circuit * result = new circuit (s->getSize () - 2);
   nr_complex_t p;
 
-  // allocate S-parameter and noise corellation matrices
+  // allocate S-parameter and noise correlation matrices
   result->initSP (); if (noise) result->initNoiseSP ();
 
   // interconnected port numbers
@@ -176,7 +176,7 @@ circuit * spsolver::connectedJoin (node * n1, node * n2) {
   circuit * result = new circuit (s->getSize () + t->getSize () - 2);
   nr_complex_t p;
 
-  // allocate S-parameter and noise corellation matrices
+  // allocate S-parameter and noise correlation matrices
   result->initSP (); if (noise) result->initNoiseSP ();
 
   // connected port numbers

--- a/src/strlist.cpp
+++ b/src/strlist.cpp
@@ -175,7 +175,7 @@ strlist * strlist::join (strlist * pre, strlist * post) {
   return res;
 }
 
-/* The function returns a space seperated string representation of the
+/* The function returns a space separated string representation of the
    string list instance. */
 char * strlist::toString (const char * concat) {
   if (txt) { free (txt); txt = NULL; }

--- a/src/trsolver.cpp
+++ b/src/trsolver.cpp
@@ -318,7 +318,7 @@ int trsolver::solve (void)
                 error++;
                 break;
             }
-            // return if any errors occured other than convergence failure
+            // return if any errors occurred other than convergence failure
             if (error) return -1;
 
             // if the step was rejected, the solution loop is restarted here

--- a/src/ucs.cpp
+++ b/src/ucs.cpp
@@ -54,7 +54,7 @@
 
 using namespace qucs;
 
-/*! \todo replace environement name root by "/" in order to be filesystem compatible */
+/*! \todo replace environment name root by "/" in order to be filesystem compatible */
 int main (int argc, char ** argv) {
 
   char * infile = NULL;

--- a/src/vector.cpp
+++ b/src/vector.cpp
@@ -1282,7 +1282,7 @@ vector smooth(vector v, nr_double_t a) {
   return runavg(extv, 2*t2+1);
 }
 
-//Ths function calculates the group delay from the svec=S[i,j] and frequency vectors
+//This function calculates the group delay from the svec=S[i,j] and frequency vectors
 vector groupdelay(vector svec, vector freq)
 {
  return -diff(unwrap(arg(svec)), (2*pi)*(freq));


### PR DESCRIPTION
Found via `codespell -q 3 -S *.eps,*.ts -L abov,alph,ba,cleare,datas,fo,gir,inout,ist,manualy,nd,pard,te,ue,varn,vectore`